### PR TITLE
Fix `AND` queries and seed scripts

### DIFF
--- a/scripts/fullscrapers/buscacursos.py
+++ b/scripts/fullscrapers/buscacursos.py
@@ -42,9 +42,9 @@ async def search_bc_code(
             try:
                 # Get or create instance
                 course_query = select(Course).where(
-                    Course.section == c["section"]
-                    and Course.term_id == term_id
-                    and Course.subject.code == c["code"]
+                    Course.section == c["section"],
+                    Course.term_id == term_id,
+                    Course.subject.code == c["code"],
                 )
                 course: Course = db_session.exec(course_query).one_or_none()
                 if not course:
@@ -150,7 +150,7 @@ async def search_bc_code(
 async def get_full_buscacursos(db_session: Session, year: int, semester: int) -> None:
     # Set term
     period = PeriodEnum.from_int(semester)
-    term_query = select(Term).where(Term.year == year and Term.period == period)
+    term_query = select(Term).where(Term.year == year, Term.period == period)
     term = db_session.exec(term_query).one_or_none()
     if not term:
         term = Term(year=year, period=period)
@@ -160,7 +160,7 @@ async def get_full_buscacursos(db_session: Session, year: int, semester: int) ->
 
     # Search all
     async with request.buscacursos() as bc_session:
-        code_generator = CodeIterator(); 
+        code_generator = CodeIterator()
         for code in code_generator:
             if await search_bc_code(code, year, semester, db_session, bc_session) >= MAX_BC:
                 code_generator.add_depth()

--- a/src/api/routes/search.py
+++ b/src/api/routes/search.py
@@ -71,7 +71,7 @@ async def get_or_create_subject(code: str, db: Session):
 
 
 async def get_or_create_academic_term(year: int, period: PeriodEnum, db: Session):
-    term = db.exec(select(Term).where(Term.year == year and Term.period == period)).one_or_none()
+    term = db.exec(select(Term).where(Term.year == year, Term.period == period)).one_or_none()
     if term:
         return term
 
@@ -110,7 +110,7 @@ async def get_or_create_courses(subject: Subject, term: Term, db: Session):
     courses_query = (
         select(Course)
         .join(Term)
-        .where(Term.year == term.year and Term.period == term.period)
+        .where(Term.year == term.year, Term.period == term.period)
         .join(Subject)
         .where(Subject.code == subject.code)
     )

--- a/src/api/routes/subject.py
+++ b/src/api/routes/subject.py
@@ -47,11 +47,11 @@ def get_all_course_sections_by_academic_period(
     # TODO: inlcude: { model: Course, where: course.randido_en = periodo academico }
     return db.exec(
         select(Course, Subject, Term).where(
-            Course.subject_id == id
-            and Term.year == year
-            and Term.period == period
-            and Course.subject_id == Subject.id
-            and Term.id == Course.term_id
+            Course.subject_id == id,
+            Term.year == year,
+            Term.period == period,
+            Course.subject_id == Subject.id,
+            Term.id == Course.term_id,
         )
     ).all()
 


### PR DESCRIPTION
+ Corrige todas los `where(...)` que contienen `AND`.
+ En los scripts de seed:
  + Corrige situaciones en que se usan ids antes de hacer commit a la BD.
  + (catalogo) Agrega un set para evitar reprocesar subjects que aparezcan en más de una búsqueda.